### PR TITLE
manifest: set clone-depth of gms to 1

### DIFF
--- a/tequila.xml
+++ b/tequila.xml
@@ -53,7 +53,7 @@
   <project path="packages/resources/devicesettings" name="platform_packages_resources_devicesettings" remote="tequila" />
 
   <!-- vendor -->
-  <project path="vendor/google/gms" name="platform_vendor_google_gms" remote="tequila-gitea" />
+  <project path="vendor/google/gms" name="platform_vendor_google_gms" remote="tequila-gitea" clone-depth="1"/>
   <project path="vendor/google/pixel" name="platform_vendor_google_pixel" remote="tequila-gitea" />
   <project path="vendor/support" name="platform_vendor_support" remote="tequila" />
   <project path="vendor/tequila" name="platform_vendor_tequila" remote="tequila" />


### PR DESCRIPTION
Fixes git error while syncing

```
error: RPC failed; curl 56 GnuTLS recv error (-110):
The TLS connection was non-properly terminated. 
fatal: the remote end hung up unexpectedly 
fatal: protocol error: bad pack header
```

due to the very large size of repository