### PR TITLE
Change repo of external/cronet to lineageOS from aosp

### DIFF
--- a/lineage.xml
+++ b/lineage.xml
@@ -12,6 +12,8 @@
   <project path="external/ant-wireless/ant_service" name="android_external_ant-wireless_ant_service" groups="qcom,sdm660" remote="lineage" />
   <project path="external/ant-wireless/hidl" name="android_external_ant-wireless_hidl" groups="qcom,qssi" remote="lineage" />
   <project path="external/json-c" name="android_external_json-c" groups="qcom,qssi" remote="lineage" />
+  <remove-project name="platform/external/cronet" />
+  <project path="external/cronet" name="android_external_cronet" groups="pdk" remote="lineage" />
 
   <!-- hardware/qcom-caf -->
   <project path="hardware/qcom-caf/bootctrl" name="android_hardware_qcom_bootctrl" groups="qcom,waipio-vendor" remote="lineage" revision="lineage-20.0-caf" />

--- a/tequila.xml
+++ b/tequila.xml
@@ -58,7 +58,7 @@
   <project path="packages/resources/devicesettings" name="platform_packages_resources_devicesettings" remote="tequila" />
 
   <!-- vendor -->
-  <project path="vendor/google/gms" name="platform_vendor_google_gms" remote="tequila-gitea" />
+  <project path="vendor/google/gms" name="platform_vendor_google_gms" remote="tequila-gitea" clone-depth="1" />
   <project path="vendor/google/pixel" name="platform_vendor_google_pixel" remote="tequila-gitea" />
   <project path="vendor/support" name="platform_vendor_support" remote="tequila" />
   <project path="vendor/tequila" name="platform_vendor_tequila" remote="tequila" />


### PR DESCRIPTION
To avoid  error of failing command running inside an sbox sandbox, change repo of external/cronet to lineageOS from aosp.